### PR TITLE
Fix CV sequences gi and qu incorrectly handled

### DIFF
--- a/src/unikey-im.cpp
+++ b/src/unikey-im.cpp
@@ -30,9 +30,9 @@ static const unsigned char WordBreakSyms[] = {
 
 static const unsigned char WordAutoCommit[] = {
     '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'b', 'c',
-    'f', 'h', 'j', 'k', 'l', 'm', 'n', 'p', 'q', 'r', 's',
+    'f', 'h', 'j', 'k', 'l', 'm', 'n', 'p', 'r', 's',
     't', 'v', 'x', 'z', 'B', 'C', 'F', 'H', 'J', 'K', 'L',
-    'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'V', 'X', 'Z'};
+    'M', 'N', 'P', 'R', 'S', 'T', 'V', 'X', 'Z'};
 
 namespace fcitx {
 

--- a/src/unikey-im.cpp
+++ b/src/unikey-im.cpp
@@ -30,8 +30,8 @@ static const unsigned char WordBreakSyms[] = {
 
 static const unsigned char WordAutoCommit[] = {
     '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'b', 'c',
-    'f', 'g', 'h', 'j', 'k', 'l', 'm', 'n', 'p', 'q', 'r', 's',
-    't', 'v', 'x', 'z', 'B', 'C', 'F', 'G', 'H', 'J', 'K', 'L',
+    'f', 'h', 'j', 'k', 'l', 'm', 'n', 'p', 'q', 'r', 's',
+    't', 'v', 'x', 'z', 'B', 'C', 'F', 'H', 'J', 'K', 'L',
     'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'V', 'X', 'Z'};
 
 namespace fcitx {


### PR DESCRIPTION
Same reason as https://github.com/fcitx/fcitx-unikey/pull/25
Summary: The CV sequence should be treated as an unit. Early commiting g ignores this, causing subsequent grammar checks to fail / tone marks inserted on the wrong character.